### PR TITLE
Add instagram-to-sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ These tools help bring the Dogsheep philosophy to life.
 * **[pinboard-to-sqlite](https://github.com/jacobian/pinboard-to-sqlite)** by Jacob Kaplan-Moss saves your bookmarks from [Pinboard](https://pinboard.in/).
 * **[todoist-to-sqlite](https://github.com/bcongdon/todoist-to-sqlite)** by Ben Congdon saves your tasks and projects from [Todoist](https://todoist.com/).
 * **[parkrun-to-sqlite](https://github.com/mrw34/parkrun-to-sqlite)** by Mark Woodbridge imports your [parkruns](https://www.parkrun.com).
+* **[instagram-to-sqlite](https://github.com/gavindsouza/instagram-to-sqlite)** by Gavin D'souza imports data from your [Instagram](https://instagram.com).


### PR DESCRIPTION
The tool covers only chat imports at the time of opening this PR but I'm planning to import everything else that I feel inquisitive about

ref: https://github.com/gavindsouza/instagram-to-sqlite